### PR TITLE
Fix render on IE11

### DIFF
--- a/hooksExample.mjs
+++ b/hooksExample.mjs
@@ -1,0 +1,72 @@
+import { createRunner, parse, PuppeteerRunnerExtension } from '@puppeteer/replay';
+import { setupEyes } from './applitools.config.mjs';
+import puppeteer from 'puppeteer';
+import fs from 'fs';
+import { Eyes, Target, VisualGridRunner } from '@applitools/eyes-puppeteer';
+
+// Puppeteer: launch browser
+const browser = await puppeteer.launch({ headless: false });
+const page = await browser.newPage();
+
+// Applitools: global variables
+let visualGridRunner = null;
+let eyes = null;
+
+// extend runner to initialize Eyes before all steps, take screenshot after each step, and close Eyes after all steps
+class Extension extends PuppeteerRunnerExtension {
+  async beforeAllSteps(flow) {
+    await super.beforeAllSteps(flow);
+    console.log('starting');
+
+    // Aplitools: launch visual grid runner & eyes
+    const apiKey = process.env.APPLITOOLS_API_KEY || 'REPLACE_YOUR_APPLITOOLS_API_KEY';
+    const name = 'Chrome Recorder Demo';
+    visualGridRunner = new VisualGridRunner({ testConcurrency: 7 });
+    eyes = new Eyes(visualGridRunner);
+
+    await setupEyes(eyes, name, apiKey);
+
+    // start the visual test
+    await eyes.open(page, {
+      appName: "Order a coffee",
+      testName: "My first Applitools Chrome Recorder test!",
+    })
+    console.log("Eyes open");
+  }
+
+  async afterEachStep(step, flow) {
+    await super.afterEachStep(step, flow);
+    
+    // capture a full-page screenshot
+    await eyes.check(`recording step: ${step.type}`, Target.window().fully(true))
+    console.log(`after step: ${step.type}`);
+  }
+
+  async afterAllSteps(flow) {
+    await super.afterAllSteps(flow);
+    console.log('done');
+
+    // Applitools: clean up
+    await eyes.closeAsync();
+    await eyes.abortAsync(); // abort if Eyes were not properly closed
+    console.log("Eyes closed");
+  }
+}
+
+// Puppeteer: Read the JSON user flow
+const recordingText = fs.readFileSync('./order-a-coffee.json', 'utf8');
+const recording = parse(JSON.parse(recordingText));
+
+// Puppeteer: Create a runner and execute the script
+const runner = await createRunner(recording, new Extension(browser, page, 7000));
+
+// Puppeteer: clean up
+await runner.run();
+await browser.close();
+
+// Manage tests across multiple Eyes instances
+const testResultsSummary = await visualGridRunner.getAllTestResults()
+for (const testResultContainer of testResultsSummary) {
+  const testResults = testResultContainer.getTestResults();
+  console.log(testResults);
+}

--- a/hooksExample.mjs
+++ b/hooksExample.mjs
@@ -12,7 +12,7 @@ const page = await browser.newPage();
 let visualGridRunner = null;
 let eyes = null;
 
-// extend runner to initialize Eyes before all steps, take screenshot after each step, and close Eyes after all steps
+// Extend runner to initialize Eyes before all steps, take screenshot after each step, and close Eyes after all steps
 class Extension extends PuppeteerRunnerExtension {
   async beforeAllSteps(flow) {
     await super.beforeAllSteps(flow);
@@ -26,7 +26,7 @@ class Extension extends PuppeteerRunnerExtension {
 
     await setupEyes(eyes, name, apiKey);
 
-    // start the visual test
+    // Applitools: start the visual test
     await eyes.open(page, {
       appName: "Order a coffee",
       testName: "My first Applitools Chrome Recorder test!",
@@ -37,7 +37,7 @@ class Extension extends PuppeteerRunnerExtension {
   async afterEachStep(step, flow) {
     await super.afterEachStep(step, flow);
     
-    // capture a full-page screenshot
+    // Applitools: capture a full-page screenshot
     await eyes.check(`recording step: ${step.type}`, Target.window().fully(true))
     console.log(`after step: ${step.type}`);
   }
@@ -53,18 +53,18 @@ class Extension extends PuppeteerRunnerExtension {
   }
 }
 
-// Puppeteer: Read the JSON user flow
+// Puppeteer: read the JSON user flow
 const recordingText = fs.readFileSync('./order-a-coffee.json', 'utf8');
 const recording = parse(JSON.parse(recordingText));
 
-// Puppeteer: Create a runner and execute the script
+// Puppeteer: create a runner and execute the script
 const runner = await createRunner(recording, new Extension(browser, page, 7000));
 
 // Puppeteer: clean up
 await runner.run();
 await browser.close();
 
-// Manage tests across multiple Eyes instances
+// Applitools: manage tests across multiple Eyes instances
 const testResultsSummary = await visualGridRunner.getAllTestResults()
 for (const testResultContainer of testResultsSummary) {
   const testResults = testResultContainer.getTestResults();

--- a/index.mjs
+++ b/index.mjs
@@ -3,7 +3,6 @@ import { setupEyes } from './applitools.config.mjs';
 import puppeteer from 'puppeteer';
 import fs from 'fs';
 import { Eyes, Target, VisualGridRunner } from '@applitools/eyes-puppeteer';
-import { config } from 'process';
 
 // extend runner to take screenshot after each step
 class Extension extends PuppeteerRunnerExtension {
@@ -29,13 +28,11 @@ await setupEyes(eyes, name, apiKey);
 await eyes.open(page, {
   appName: "Order a coffee",
   testName: "My First Applitools Chrome Recorder test!",
-  visualGridOptions: {
-    "ieV2": true
-  }
+  visualGridOptions: { "ieV2": true }
 });
 
 // Puppeteer: Read the JSON user flow
-const recordingText = fs.readFileSync('./order-coffe.json', 'utf8');
+const recordingText = fs.readFileSync('./order-a-coffee.json', 'utf8');
 const recording = parse(JSON.parse(recordingText));
 
 // Puppeteer: Create a runner and execute the script

--- a/index.mjs
+++ b/index.mjs
@@ -4,7 +4,7 @@ import puppeteer from 'puppeteer';
 import fs from 'fs';
 import { Eyes, Target, VisualGridRunner } from '@applitools/eyes-puppeteer';
 
-// extend runner to take screenshot after each step
+// Extend runner to take screenshot after each step
 class Extension extends PuppeteerRunnerExtension {
   async afterEachStep(step, flow) {
     await super.afterEachStep(step, flow);
@@ -31,11 +31,11 @@ await eyes.open(page, {
   visualGridOptions: { "ieV2": true }
 });
 
-// Puppeteer: Read the JSON user flow
+// Puppeteer: read the JSON user flow
 const recordingText = fs.readFileSync('./order-a-coffee.json', 'utf8');
 const recording = parse(JSON.parse(recordingText));
 
-// Puppeteer: Create a runner and execute the script
+// Puppeteer: create a runner and execute the script
 const runner = await createRunner(recording, new Extension(browser, page, 7000));
 
 // Puppeteer: clean up
@@ -46,7 +46,7 @@ await browser.close();
 await eyes.closeAsync();
 await eyes.abortAsync(); // abort if Eyes were not properly closed
 
-// Manage tests across multiple Eyes instances
+// Applitools: Manage tests across multiple Eyes instances
 const testResultsSummary = await visualGridRunner.getAllTestResults()
 for (const testResultContainer of testResultsSummary) {
   const testResults = testResultContainer.getTestResults();

--- a/index.mjs
+++ b/index.mjs
@@ -3,6 +3,7 @@ import { setupEyes } from './applitools.config.mjs';
 import puppeteer from 'puppeteer';
 import fs from 'fs';
 import { Eyes, Target, VisualGridRunner } from '@applitools/eyes-puppeteer';
+import { config } from 'process';
 
 // extend runner to take screenshot after each step
 class Extension extends PuppeteerRunnerExtension {
@@ -23,11 +24,18 @@ const name = 'Chrome Recorder Demo';
 const visualGridRunner = new VisualGridRunner({ testConcurrency: 5 });
 const eyes = new Eyes(visualGridRunner);
 
+
 await setupEyes(eyes, name, apiKey);
-await eyes.open(page, "Order a coffee", "My first Applitools Chrome Recorder test!");
+await eyes.open(page, {
+  appName: "Order a coffee",
+  testName: "My First Applitools Chrome Recorder test!",
+  visualGridOptions: {
+    "ieV2": true
+  }
+});
 
 // Puppeteer: Read the JSON user flow
-const recordingText = fs.readFileSync('./order-a-coffee.json', 'utf8');
+const recordingText = fs.readFileSync('./order-coffe.json', 'utf8');
 const recording = parse(JSON.parse(recordingText));
 
 // Puppeteer: Create a runner and execute the script

--- a/index.mjs
+++ b/index.mjs
@@ -8,7 +8,7 @@ import { Eyes, Target, VisualGridRunner } from '@applitools/eyes-puppeteer';
 class Extension extends PuppeteerRunnerExtension {
   async afterEachStep(step, flow) {
     await super.afterEachStep(step, flow);
-    await eyes.check('demo page', Target.window().fully(false));
+    await eyes.check(`recording step: ${step.type}`, Target.window().fully(false));
     console.log(`after step: ${step.type}`);
   }
 }
@@ -42,9 +42,9 @@ await eyes.closeAsync();
 await eyes.abortAsync(); // abort if Eyes were not properly closed
 
 // Manage tests across multiple Eyes instances
-// const testResultsSummary = await visualGridRunner.getAllTestResults()
-// for (const testResultContainer of testResultsSummary) {
-//   const testResults = testResultContainer.getTestResults();
-//   console.log(testResults);
-// }
+const testResultsSummary = await visualGridRunner.getAllTestResults()
+for (const testResultContainer of testResultsSummary) {
+  const testResults = testResultContainer.getTestResults();
+  console.log(testResults);
+}
 

--- a/order-a-coffee.json
+++ b/order-a-coffee.json
@@ -2,6 +2,15 @@
   "title": "order-a-coffee",
   "steps": [
     {
+      "type": "setViewport",
+      "width": 380,
+      "height": 604,
+      "deviceScaleFactor": 1,
+      "isMobile": false,
+      "hasTouch": false,
+      "isLandscape": false
+    },
+    {
       "type": "navigate",
       "assertedEvents": [
         {
@@ -11,15 +20,6 @@
         }
       ],
       "url": "https://coffee-cart.netlify.app/"
-    },
-    {
-      "type": "setViewport",
-      "width": 380,
-      "height": 604,
-      "deviceScaleFactor": 1,
-      "isMobile": false,
-      "hasTouch": false,
-      "isLandscape": false
     },
     {
       "type": "click",

--- a/order-a-coffee.json
+++ b/order-a-coffee.json
@@ -2,15 +2,6 @@
   "title": "order-a-coffee",
   "steps": [
     {
-      "type": "setViewport",
-      "width": 380,
-      "height": 604,
-      "deviceScaleFactor": 1,
-      "isMobile": false,
-      "hasTouch": false,
-      "isLandscape": false
-    },
-    {
       "type": "navigate",
       "assertedEvents": [
         {
@@ -20,6 +11,15 @@
         }
       ],
       "url": "https://coffee-cart.netlify.app/"
+    },
+    {
+      "type": "setViewport",
+      "width": 380,
+      "height": 604,
+      "deviceScaleFactor": 1,
+      "isMobile": false,
+      "hasTouch": false,
+      "isLandscape": false
     },
     {
       "type": "click",


### PR DESCRIPTION
The first render is failing on IE11 since the first step is setting the viewport size and the Ultra Fast Grid has no DOM snapshot to re-render the job. By navigating to the page first and then setting the viewport we see a successful execution.

Added another example that utilizes more hooks.